### PR TITLE
Add download functionnality

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,9 @@
 'use strict';
 module.exports = function (grunt) {
 	grunt.initConfig({
+		dirs: {
+			local: __dirname
+		},
 		ftp: {
 			test: {
 				options: {
@@ -14,13 +17,27 @@ module.exports = function (grunt) {
 				}
 			}
 		},
+		ftpGet: {
+			test: {
+				options: {
+					host: 'localhost',
+					port: 3334,
+					user: 'test',
+					pass: 'test'
+				},
+				files: {
+					'fixtureGet/fixture2.txt': 'ftp/fixture/fixture.txt',
+					'<%= dirs.local %>/fixtureGet': 'ftp/fixture/fixture.txt'
+				}
+			}
+		},
 		simplemocha: {
 			test: {
 				src: 'test.js'
 			}
 		},
 		clean: {
-			test: ['ftp']
+			test: ['ftp', 'fixtureGet']
 		}
 	});
 
@@ -53,6 +70,7 @@ module.exports = function (grunt) {
 		'clean',
 		'pre',
 		'ftp',
+		'ftpGet',
 		'simplemocha',
 		'post',
 		'clean'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,7 @@ module.exports = function (grunt) {
 		dirs: {
 			local: __dirname
 		},
-		ftp: {
+		ftpPut: {
 			test: {
 				options: {
 					host: 'localhost',
@@ -69,7 +69,7 @@ module.exports = function (grunt) {
 	grunt.registerTask('default', [
 		'clean',
 		'pre',
-		'ftp',
+		'ftpPut',
 		'ftpGet',
 		'simplemocha',
 		'post',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-ftp",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "description": "Upload files to an FTP-server",
   "license": "MIT",
   "repository": "sindresorhus/grunt-ftp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-ftp",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Upload files to an FTP-server",
   "license": "MIT",
   "repository": "sindresorhus/grunt-ftp",

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # grunt-ftp [![Build Status](https://travis-ci.org/sindresorhus/grunt-ftp.svg?branch=master)](https://travis-ci.org/sindresorhus/grunt-ftp)
 
-> Upload files to an FTP-server
+> Upload or Download files to / from an FTP-Server
 
-Useful for uploading and deploying things.
+Useful for uploading, deploying and downloading things.
 
 
 ## Install
@@ -12,7 +12,7 @@ $ npm install --save-dev grunt-ftp
 ```
 
 
-## Usage
+## Upload Usage
 
 ```js
 require('load-grunt-tasks')(grunt); // npm install --save-dev load-grunt-tasks
@@ -35,6 +35,28 @@ grunt.initConfig({
 grunt.registerTask('default', ['ftp']);
 ```
 
+## Download Usage
+
+```js
+require('load-grunt-tasks')(grunt); // npm install --save-dev load-grunt-tasks
+
+grunt.initConfig({
+	ftpGet: {
+		options: {
+			host: 'website.com',
+			user: 'johndoe',
+			pass: '1234'
+		},
+		upload: {
+			files: {
+				'public_html': 'src/file.txt'
+			}
+		}
+	}
+});
+
+grunt.registerTask('default', ['ftp']);
+```
 
 ## Options
 
@@ -58,6 +80,9 @@ Default: `'anonymous'`
 Type: `string`  
 Default: `'@anonymous'`
 
+## Notes
+
+For downloading task, if dest path is a folder that doesn't exists, this will be create
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ $ npm install --save-dev grunt-ftp
 require('load-grunt-tasks')(grunt); // npm install --save-dev load-grunt-tasks
 
 grunt.initConfig({
-	ftp: {
+	ftpPut: {
 		options: {
 			host: 'website.com',
 			user: 'johndoe',
@@ -32,7 +32,7 @@ grunt.initConfig({
 	}
 });
 
-grunt.registerTask('default', ['ftp']);
+grunt.registerTask('default', ['ftpPut']);
 ```
 
 ## Download Usage
@@ -47,15 +47,15 @@ grunt.initConfig({
 			user: 'johndoe',
 			pass: '1234'
 		},
-		upload: {
+		download: {
 			files: {
-				'public_html': 'src/file.txt'
+				'public_html/file.txt': 'src/file.txt'
 			}
 		}
 	}
 });
 
-grunt.registerTask('default', ['ftp']);
+grunt.registerTask('default', ['ftpGet']);
 ```
 
 ## Options
@@ -79,10 +79,6 @@ Default: `'anonymous'`
 
 Type: `string`  
 Default: `'@anonymous'`
-
-## Notes
-
-For downloading task, if dest path is a folder that doesn't exists, this will be create
 
 ## License
 

--- a/tasks/ftp.js
+++ b/tasks/ftp.js
@@ -7,7 +7,7 @@ var JSFtp = require('jsftp');
 JSFtp = require('jsftp-mkdirp')(JSFtp);
 
 module.exports = function (grunt) {
-	grunt.registerMultiTask('ftp', 'Upload files to an FTP-server', function () {
+	grunt.registerMultiTask('ftpPut', 'Upload files to an FTP-server', function () {
 		var done = this.async();
 		var options = this.options();
 		var fileCount = 0;
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
 			var finalLocalPath = el.dest;
 			if(grunt.file.isDir(el.dest)) {
 				// if dest is a directory, have to create a file with source filename
-				var filename = path.parse(el.src[0]).name + path.parse(el.src[0]).ext;
+				var filename = path.basename(el.src[0]);
 				finalLocalPath = path.join(el.dest, '/', filename);
 			}
 

--- a/tasks/ftp.js
+++ b/tasks/ftp.js
@@ -71,16 +71,13 @@ module.exports = function (grunt) {
 			// have to create a new connection for each file otherwise they conflict
 			var ftp = new JSFtp(options);
 
-			if(!grunt.file.exists(el.dest)) {
-				// if dest path doesn't exists, we create the full dirname
-				grunt.file.mkdir(path.dirname(el.dest));
-			}
+			grunt.file.mkdir(path.dirname(el.dest));
 
 			var finalLocalPath = el.dest;
 			if(grunt.file.isDir(el.dest)) {
 				// if dest is a directory, have to create a file with source filename
 				var filename = path.basename(el.src[0]);
-				finalLocalPath = path.join(el.dest, '/', filename);
+				finalLocalPath = path.join(el.dest, filename);
 			}
 
 			// retrieve the file

--- a/tasks/ftp.js
+++ b/tasks/ftp.js
@@ -74,7 +74,7 @@ module.exports = function (grunt) {
 			grunt.file.mkdir(path.dirname(el.dest));
 
 			var finalLocalPath = el.dest;
-			if(grunt.file.isDir(el.dest)) {
+			if (grunt.file.isDir(el.dest)) {
 				// if dest is a directory, have to create a file with source filename
 				var filename = path.basename(el.src[0]);
 				finalLocalPath = path.join(el.dest, filename);

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ it('should upload files to an FTP-server', function () {
 	assert(grunt.file.exists('ftp/fixture/fixture.txt'));
 });
 
-it('should create a new folder for retrieve files', function() {
+it('should create a new folder for retrieve files', function () {
 	assert(grunt.file.isDir('fixtureGet'));
 });
 

--- a/test.js
+++ b/test.js
@@ -5,3 +5,12 @@ var grunt = require('grunt');
 it('should upload files to an FTP-server', function () {
 	assert(grunt.file.exists('ftp/fixture/fixture.txt'));
 });
+
+it('should create a new folder for retrieve files', function() {
+	assert(grunt.file.isDir('fixtureGet'));
+});
+
+it('should download 2 files from an FTP-server', function () {
+	assert(grunt.file.exists('fixtureGet/fixture.txt') && grunt.file.isFile('fixtureGet/fixture.txt'));
+	assert(grunt.file.exists('fixtureGet/fixture2.txt') && grunt.file.isFile('fixtureGet/fixture2.txt'))
+});


### PR DESCRIPTION
Hello,

I'm user of your grunt plugin grunt-ftp, and for some projects we need to put and get some files in an FTP Server.
Like i don't find some grunt plugin which do the both, i add this functionnality into your plugin.

Let me know if what i've done is great or if it's need to change some other things.

I don't have think of comptability with older version, so maybe we will need to rename ftpPut task to its older name.

PS : Sorry my english, i'm french.

Regards,
